### PR TITLE
Add support for ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.11-slim
 
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libldap2-dev \
+    libsasl2-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 ADD imperial_coldfront_plugin /usr/src/imperial_coldfront_plugin
 WORKDIR /usr/src/
 RUN pip install -r imperial_coldfront_plugin/requirements.txt && pip install -e imperial_coldfront_plugin

--- a/coldfront_overrides/plugin_settings.py
+++ b/coldfront_overrides/plugin_settings.py
@@ -1,1 +1,3 @@
 INSTALLED_APPS += ["imperial_coldfront_plugin"]
+
+from imperial_coldfront_plugin.settings import *

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - "OIDC_RP_SCOPES=openid email profile"
       - PLUGIN_AUTH_OIDC
       - PLUGIN_ICL=True
+      - LDAP_SERVER_URI
+      - LDAP_SEARCH_BASE=ou=everyone,dc=ic,dc=ac,dc=uk
     volumes:
       - ./local_settings.py:/etc/coldfront/local_settings.py:ro
       - ./imperial_coldfront_plugin/:/usr/src/imperial_coldfront_plugin/


### PR DESCRIPTION
Add necessary prerequisites to the development environment to support use of the `python-ldap` package. This needed to support the changes made in imperialcollegelondon/imperial_coldfront_plugin#42